### PR TITLE
Fix scrolling

### DIFF
--- a/protected/widgets/menu/assets/menu.css
+++ b/protected/widgets/menu/assets/menu.css
@@ -41,6 +41,7 @@
     --item-padding-vertical: 18px;
     --side-width: 285px;
     padding-top: 10px;
+    height: 100vh;
     position: relative;
     border-bottom-right-radius: 5px;
     background-color: white;
@@ -292,7 +293,7 @@
 }
 
 .menu.collapsible {
-    height: 100%;
+    height: 100vh;
     transition-duration: var(--animation-duration);
     transition-property: height;
 }

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -586,7 +586,7 @@ body {
 
     .user-menu {
         text-align: right;
-        padding: 20px 10px 20px 0;  
+        padding: 20px 10px 20px 0;
     }
 
     body.no-title .user-menu {
@@ -615,6 +615,7 @@ body {
                 "sidebar filters filters filters"
                 "sidebar main main main"
         ;
+        height: 100vh;
     }
 
     .content {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -136,8 +136,7 @@ a:hover {
         display: block;
         overflow-y: auto;
         position: relative;
-        height: 100vh;
-        padding: 30px 10px 100px 10px;
+        padding: 10px 10px 100px 10px;
     }
 }
 


### PR DESCRIPTION
Fix for the scrolling in limesurvey that were hiding the bottom of the screen

![Capture d’écran 2020-04-02 à 14 50 46](https://user-images.githubusercontent.com/2345926/78251243-5ded6200-74f1-11ea-968b-fe4d52a2bf4e.png)

Problem was that the content was too tall.
Removed the 100vh height of the content and added it to the body.
That way the body takes the height of the screen, allowing the content to have the right height

I've leff the padding-bottom: 100px so that the last element is not too close from the bottom of the screen.

![Capture d’écran 2020-04-02 à 14 49 48](https://user-images.githubusercontent.com/2345926/78251303-6fcf0500-74f1-11ea-933a-a93e37fb3c5b.png)


