### PR TITLE
World map : limiting max zoom to country level

### DIFF
--- a/protected/widgets/map/Map.php
+++ b/protected/widgets/map/Map.php
@@ -73,7 +73,7 @@ HTML;
             'center' => $this->center,
             'zoom' => $this->zoom,
             'zoomControl' => false,
-            'maxZoom' => 16,
+            'maxZoom' => 6,
             'minZoom' => 3
         ]);
 


### PR DESCRIPTION
Limiting the world map zoom to 6, as there is no need to see more than a country

![Capture d’écran 2020-04-28 à 18 31 13](https://user-images.githubusercontent.com/2345926/80512865-76308f80-897e-11ea-99dc-f471d4d45b22.png)
