### PR TITLE
Admin pages layout

### DIFF
--- a/protected/controllers/ElementController.php
+++ b/protected/controllers/ElementController.php
@@ -3,7 +3,6 @@
 
 namespace prime\controllers;
 
-
 use prime\actions\DeleteAction;
 use prime\components\Controller;
 use prime\controllers\element\Create;
@@ -15,7 +14,7 @@ use yii\helpers\ArrayHelper;
 
 class ElementController extends Controller
 {
-    public $layout = 'admin';
+    public $layout = 'form';
     public function actions()
     {
         return [
@@ -25,7 +24,7 @@ class ElementController extends Controller
             'delete' => [
                 'class' => DeleteAction::class,
                 'query' => Element::find(),
-                'redirect' => function(Element $element) {
+                'redirect' => function (Element $element) {
                     return ['page/update', 'id' => $element->page_id];
                 }
             ]
@@ -34,7 +33,8 @@ class ElementController extends Controller
 
     public function behaviors()
     {
-        return ArrayHelper::merge(parent::behaviors(),
+        return ArrayHelper::merge(
+            parent::behaviors(),
             [
                 'verbs' => [
                     'class' => VerbFilter::class,

--- a/protected/controllers/ResponseController.php
+++ b/protected/controllers/ResponseController.php
@@ -8,7 +8,7 @@ use prime\controllers\response\Compare;
 
 class ResponseController extends Controller
 {
-    public $layout = '//admin';
+    public $layout = 'admin';
     public function actions(): array
     {
         return [

--- a/protected/controllers/WorkspaceController.php
+++ b/protected/controllers/WorkspaceController.php
@@ -25,7 +25,7 @@ use yii\web\User;
 
 class WorkspaceController extends Controller
 {
-    public $layout = '//admin';
+    public $layout = 'admin';
 
     public function actions()
     {

--- a/protected/views/element/preview.php
+++ b/protected/views/element/preview.php
@@ -14,13 +14,8 @@ $this->registerCss(<<<CSS
     }
 
 .content {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
-    width: 100vw;
     padding: 0;
-    height: 100vh;
-    
+    display: block;
 }
 CSS
 );

--- a/protected/views/element/preview.php
+++ b/protected/views/element/preview.php
@@ -11,11 +11,11 @@ $this->registerAssetBundle(\yii\web\JqueryAsset::class);
 $this->registerCss(<<<CSS
     body {
         display: block;
+        background: none;
     }
 
 .content {
     padding: 0;
-    display: block;
 }
 CSS
 );

--- a/protected/views/element/update.php
+++ b/protected/views/element/update.php
@@ -34,7 +34,7 @@ $this->title = $model->isNewRecord
     ? \Yii::t('app', 'Create element')
     : \Yii::t('app', 'Update element');
 $this->params['breadcrumbs'][] = $this->title;
-$grid = $model->type  == 'map' ? 'grid-column: span 2; grid-row: span 2; height: 400px;' : 'grid-row: span 1; grid-column: span 2;';
+$grid = $model->type  == 'map' ? 'grid-column: span 2; grid-row: span 2;' : 'grid-row: span 1; grid-column: span 2;';
 ?>
 <div style='<?= $grid; ?>'>
     <?php

--- a/protected/views/element/update.php
+++ b/protected/views/element/update.php
@@ -34,9 +34,31 @@ $this->title = $model->isNewRecord
     ? \Yii::t('app', 'Create element')
     : \Yii::t('app', 'Update element');
 $this->params['breadcrumbs'][] = $this->title;
-
+$grid = $model->type  == 'map' ? 'grid-area: span 2 / span 3 / auto / auto;' : 'grid-row: span 1; grid-column: span 2;';
 ?>
-<div class="col-xs-12 col-md-4 form-content form-bg">
+<div style='<?= $grid; ?>'>
+    <?php
+    if (isset($model->id)) {
+        $params = ['element/preview'];
+        foreach ($model->safeAttributes() as $attribute) {
+            $params[Html::getInputName($model, $attribute)] = $model->$attribute;
+        }
+        $params['id'] = $model->id;
+        echo Html::tag('iframe', '', [
+            'id' => 'preview-frame',
+            'src' => Url::to($params),
+            'class' => ['form-bg'],
+            'style' => [
+                'border' => 'none',
+                'width' => '100%',
+                'height' => '100%',
+                'background-color' => 'white'
+            ]
+        ]);
+    }
+    ?>
+</div>
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Update element')?></h3>
     <?php
     $form = ActiveForm::begin([
@@ -181,28 +203,5 @@ JS
     ]);
     $form->end();
 
-    ?>
-</div>
-<div class="col-xs-12 col-md-8">
-    <?php
-    if (isset($model->id)) {
-        $params = ['element/preview'];
-        foreach ($model->safeAttributes() as $attribute) {
-            $params[Html::getInputName($model, $attribute)] = $model->$attribute;
-        }
-        $params['id'] = $model->id;
-        echo Html::tag('iframe', '', [
-            'id' => 'preview-frame',
-            'src' => Url::to($params),
-            'class' => ['form-bg'],
-            'style' => [
-                'border' => 'none',
-                'width' => '100%',
-                'min-height' => '500px',
-                'height' => '100%',
-                'background-color' => 'white'
-            ]
-        ]);
-    }
     ?>
 </div>

--- a/protected/views/element/update.php
+++ b/protected/views/element/update.php
@@ -34,7 +34,7 @@ $this->title = $model->isNewRecord
     ? \Yii::t('app', 'Create element')
     : \Yii::t('app', 'Update element');
 $this->params['breadcrumbs'][] = $this->title;
-$grid = $model->type  == 'map' ? 'grid-area: span 2 / span 3 / auto / auto;' : 'grid-row: span 1; grid-column: span 2;';
+$grid = $model->type  == 'map' ? 'grid-column: span 2; grid-row: span 2; height: 400px;' : 'grid-row: span 1; grid-column: span 2;';
 ?>
 <div style='<?= $grid; ?>'>
     <?php

--- a/protected/views/layouts/admin.php
+++ b/protected/views/layouts/admin.php
@@ -16,7 +16,7 @@ echo Html::tag('div', $content, ['class' => [
     "action-{$this->context->action->id}"
 
 ], 'style' => [
-    'display' => 'block',
+    //'display' => 'block',
 //    'grid-template-columns' => 'auto',
 //    'grid-template-rows' => 'auto'
 //        grid-auto-rows: 200px;

--- a/protected/views/page/create.php
+++ b/protected/views/page/create.php
@@ -24,7 +24,7 @@ $this->title = \Yii::t('app', 'Create page');
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Create Page')?></h3>
     <?php
 

--- a/protected/views/page/update.php
+++ b/protected/views/page/update.php
@@ -31,7 +31,7 @@ $this->params['breadcrumbs'][] = [
 $this->title = $page->title;
 $this->params['breadcrumbs'][] = $this->title;
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Update Page')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/protected/views/project/create.php
+++ b/protected/views/project/create.php
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = [
 ];
 
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Create Project')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/protected/views/project/import.php
+++ b/protected/views/project/import.php
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = [
 $this->title = 'Import pages';
 $this->params['breadcrumbs'][] = $this->title;
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Import Project')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/protected/views/project/pages.php
+++ b/protected/views/project/pages.php
@@ -33,7 +33,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Pages')?></h3>
     <?php
     echo GridView::widget([

--- a/protected/views/project/pages.php
+++ b/protected/views/project/pages.php
@@ -33,7 +33,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 
 ?>
-<div class="form-content form-bg">
+<div class="form-content form-bg full-width">
     <h3><?=\Yii::t('app', 'Pages')?></h3>
     <?php
     echo GridView::widget([

--- a/protected/views/project/share.php
+++ b/protected/views/project/share.php
@@ -24,7 +24,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 <div class="col-xs-12 share-form">
-    <div class="col-xs-12 form-content permissions-form form-bg">
+    <div class="form-content permissions-form form-bg">
         <?php
         echo Html::tag('h3', \Yii::t('app', 'Add permissions'));
         $form = ActiveForm::begin([

--- a/protected/views/project/share.php
+++ b/protected/views/project/share.php
@@ -23,37 +23,36 @@ $this->title = \Yii::t('app', 'Manage user permissions for {project}', ['project
 $this->params['breadcrumbs'][] = $this->title;
 
 ?>
-<div class="col-xs-12 share-form">
-    <div class="form-content permissions-form form-bg">
-        <?php
-        echo Html::tag('h3', \Yii::t('app', 'Add permissions'));
-        $form = ActiveForm::begin([
-            "type" => ActiveForm::TYPE_HORIZONTAL,
-            'formConfig' => [
-                'showLabels' => true,
-                'defaultPlaceholder' => false
 
-            ]
-        ]);
-        echo $model->renderForm($form);
-        echo Form::widget([
-            'form' => $form,
-            'model' => $model,
-            'attributes' => [
-                FormButtonsWidget::embed([
-                    'buttons' => [
-                        ['label' => \Yii::t('app', 'Add'), 'options' => ['class' => ['btn', 'btn-primary']]]
-                    ]
-                ])
-            ]
-        ]);
-        $form->end();
-        ?>
-    </div>
-    <div class="col-xs-12 form-content list-shared form-bg">
-        <h3><?= \Yii::t('app', 'View user permissions') ?></h3>
-        <?php
-        echo $model->renderTable();
-        ?>
-    </div>
+<div class="form-content form-bg">
+    <?php
+    echo Html::tag('h3', \Yii::t('app', 'Add permissions'));
+    $form = ActiveForm::begin([
+        "type" => ActiveForm::TYPE_HORIZONTAL,
+        'formConfig' => [
+            'showLabels' => true,
+            'defaultPlaceholder' => false
+
+        ]
+    ]);
+    echo $model->renderForm($form);
+    echo Form::widget([
+        'form' => $form,
+        'model' => $model,
+        'attributes' => [
+            FormButtonsWidget::embed([
+                'buttons' => [
+                    ['label' => \Yii::t('app', 'Add'), 'options' => ['class' => ['btn', 'btn-primary']]]
+                ]
+            ])
+        ]
+    ]);
+    $form->end();
+    ?>
+</div>
+<div class="form-content form-bg full-width">
+    <h3><?= \Yii::t('app', 'View user permissions') ?></h3>
+    <?php
+    echo $model->renderTable();
+    ?>
 </div>

--- a/protected/views/project/update.php
+++ b/protected/views/project/update.php
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = [
 $this->title = $model->title;
 $this->params['breadcrumbs'][] = $this->title;
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6  form-content form-bg">
+<div class="form-content form-bg">
     <?php
     echo Html::tag('h3', \Yii::t('app', 'Update ').' '.$this->title);
     $form = ActiveForm::begin([
@@ -55,8 +55,11 @@ $this->params['breadcrumbs'][] = $this->title;
                 'widgetClass' => \kartik\select2\Select2::class,
                 'options' => [
                 'data' => \yii\helpers\ArrayHelper::map(
-                        [['alpha3' => '', 'name' => \Yii::t('app', '(Not set)')]] +
-                        (new League\ISO3166\ISO3166())->all(), 'alpha3', 'name')
+                    [['alpha3' => '', 'name' => \Yii::t('app', '(Not set)')]] +
+                    (new League\ISO3166\ISO3166())->all(),
+                    'alpha3',
+                    'name'
+                )
                 ]
             ],
             'typemapAsJson' => [

--- a/protected/views/project/view.php
+++ b/protected/views/project/view.php
@@ -35,7 +35,7 @@ while (null !== ($parent = $parent->getParentPage())) {
     $stack[] = $parent;
 }
 
-while(!empty($stack)) {
+while (!empty($stack)) {
     /** @var PageInterface $p */
     $p = array_pop($stack);
     $this->params['breadcrumbs'][] = [
@@ -65,33 +65,34 @@ echo $this->render('view/filters', [
     'filterModel' => $filterModel,
     'data' => $data
 ]);
-echo Html::beginTag('div', ['class' => 'content']);
+echo Html::beginTag('div', ['class' => 'content dashboard']);
 
-    foreach($page->getChildElements() as $element) {
-        Yii::beginProfile('Render element ' . $element->id);
-        echo "<!-- Begin chart {$element->id} -->";
-        $level = ob_get_level();
-        ob_start();
-        try {
-            echo $element->getWidget($survey, $data, $page)->run();
-            echo ob_get_clean();
-        } catch (Throwable $t) {
-            if (!YII_ENV_PROD) {
-                throw $t;
-            }
-            while (ob_get_level() > $level) {
-                ob_end_clean();
-            }
-            \Yii::error($t);
-            echo Html::tag('div',
-                "Rendering this element caused an error: <strong>{$t->getMessage()}</strong>. The most common reason for the error is an invalid question code in its configuration. You can edit the element " . Html::a('here', ['/element/update', 'id' => $element->id]) . '.',
-                [
-                    'class' => 'element',
-                ]
-            );
+foreach ($page->getChildElements() as $element) {
+    Yii::beginProfile('Render element ' . $element->id);
+    echo "<!-- Begin chart {$element->id} -->";
+    $level = ob_get_level();
+    ob_start();
+    try {
+        echo $element->getWidget($survey, $data, $page)->run();
+        echo ob_get_clean();
+    } catch (Throwable $t) {
+        if (!YII_ENV_PROD) {
+            throw $t;
         }
-        echo "<!-- End chart {$element->id} -->";
-        Yii::endProfile('Render element ' . $element->id);
+        while (ob_get_level() > $level) {
+            ob_end_clean();
+        }
+        \Yii::error($t);
+        echo Html::tag(
+            'div',
+            "Rendering this element caused an error: <strong>{$t->getMessage()}</strong>. The most common reason for the error is an invalid question code in its configuration. You can edit the element " . Html::a('here', ['/element/update', 'id' => $element->id]) . '.',
+            [
+                'class' => 'element',
+                ]
+        );
     }
+    echo "<!-- End chart {$element->id} -->";
+    Yii::endProfile('Render element ' . $element->id);
+}
 
 echo Html::endTag('div');

--- a/protected/views/workspace/configure.php
+++ b/protected/views/workspace/configure.php
@@ -30,7 +30,7 @@ $this->params['breadcrumbs'][] = [
 $this->title = Yii::t('app', 'Update workspace token');
 $this->params['breadcrumbs'][] = $this->title;
 ?>
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Update workspace token')?></h3>
 <?php
 $form = ActiveForm::begin([

--- a/protected/views/workspace/create.php
+++ b/protected/views/workspace/create.php
@@ -26,7 +26,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Create Workspace')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/protected/views/workspace/import.php
+++ b/protected/views/workspace/import.php
@@ -32,7 +32,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Import Workspace')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/protected/views/workspace/share.php
+++ b/protected/views/workspace/share.php
@@ -26,44 +26,38 @@ $this->params['breadcrumbs'][] = [
 $this->title = \Yii::t('app', 'Share workspace {workspace}', ['workspace' => $workspace->title]);
 $this->params['breadcrumbs'][] = $this->title;
 
-
-
-
 ?>
-<div class="col-xs-12 share-form">
-    <div class="col-xs-12 form-content permissions-form form-bg">
-        <?php
-        echo Html::tag('h3', \Yii::t('app', 'Add permissions'));
-        $form = ActiveForm::begin([
-            'method' => 'POST',
-            "type" => ActiveForm::TYPE_HORIZONTAL,
-            'formConfig' => [
-                'showLabels' => true,
-                'defaultPlaceholder' => false
-            ]
-        ]);
 
-        echo $model->renderForm($form);
-        echo Form::widget([
-            'form' => $form,
-            'model' => $model,
-            'attributes' => [
-                FormButtonsWidget::embed([
-                    'buttons' => [
-                        ['label' => \Yii::t('app', 'Add'), 'options' => ['class' => ['btn', 'btn-primary']]]
-                    ]
-                ])
-            ]
-        ]);
-        $form->end();
-        ?>
-    </div>
-    <div class="col-xs-12 form-content list-shared form-bg">
-        <h3><?=\Yii::t('app', 'View user permissions')?></h3>
-        <?php
-        echo $model->renderTable();
-        ?>
-    </div>
+<div class="form-content form-bg">
+    <?php
+    echo Html::tag('h3', \Yii::t('app', 'Add permissions'));
+    $form = ActiveForm::begin([
+        'method' => 'POST',
+        "type" => ActiveForm::TYPE_HORIZONTAL,
+        'formConfig' => [
+            'showLabels' => true,
+            'defaultPlaceholder' => false
+        ]
+    ]);
+
+    echo $model->renderForm($form);
+    echo Form::widget([
+        'form' => $form,
+        'model' => $model,
+        'attributes' => [
+            FormButtonsWidget::embed([
+                'buttons' => [
+                    ['label' => \Yii::t('app', 'Add'), 'options' => ['class' => ['btn', 'btn-primary']]]
+                ]
+            ])
+        ]
+    ]);
+    $form->end();
+    ?>
 </div>
-
-
+<div class="form-content form-bg">
+    <h3><?= \Yii::t('app', 'View user permissions') ?></h3>
+    <?php
+    echo $model->renderTable();
+    ?>
+</div>

--- a/protected/views/workspace/share.php
+++ b/protected/views/workspace/share.php
@@ -55,7 +55,7 @@ $this->params['breadcrumbs'][] = $this->title;
     $form->end();
     ?>
 </div>
-<div class="form-content form-bg">
+<div class="form-content form-bg full-width">
     <h3><?= \Yii::t('app', 'View user permissions') ?></h3>
     <?php
     echo $model->renderTable();

--- a/protected/views/workspace/update.php
+++ b/protected/views/workspace/update.php
@@ -31,7 +31,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
 ?>
 
-<div class="col-xs-12 col-md-8 col-lg-6 form-content form-bg">
+<div class="form-content form-bg">
     <h3><?=\Yii::t('app', 'Update Workspace')?></h3>
     <?php
     $form = ActiveForm::begin([

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -151,6 +151,11 @@ a {
     margin: 0 0 0 10px;
 }
 
+
+.user-menu span {
+    font-size: 11px;
+}
+
 .user-menu a, .user-menu a:visited {
     text-decoration: inherit;
     color: inherit;
@@ -423,7 +428,6 @@ span.header {
     background-color: var(--main-background-color);
     grid-area: main;
     position: relative;
-    ;
 }
 
 .content.maximized {
@@ -633,11 +637,12 @@ body {
     vertical-align: bottom;
 }
 
-
 .form-content {
-    max-width: 750px;
     margin-bottom: 30px;
     padding: 20px;
+    height: max-content;
+    grid-row: auto;
+    grid-column: span 3;
 }
 
 .form-content h3 {
@@ -710,6 +715,14 @@ body {
         grid-auto-flow: dense;
         grid-row-gap: var(--gutter-size);
         grid-column-gap: var(--gutter-size);
+    }
+    .content.layout-admin {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+    .content.layout-admin.action-update {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+        grid-template-rows: repeat(auto-fit, minmax(200px, 33%));
     }
     .map {
         grid-column: span 1;

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -165,7 +165,7 @@ a {
     margin-left: 10px;
 }
 
-.user-menu a:first-child{
+.user-menu a:first-child {
     border-left: none;
     margin-left: 0;
     padding-left: 0;
@@ -187,14 +187,15 @@ body.no-title .user-menu a:hover {
     max-height: 50px;
     border-radius: 50%;
 }
-.user-menu .name{
+
+.user-menu .name {
     color: var(--username-color);
     text-decoration: none;
     text-transform: uppercase;
     font-weight: 600;
     font-size: 15px;
     line-height: 15px;
-    border:none;
+    border: none;
     margin: 0;
     padding: 0;
 }
@@ -205,13 +206,16 @@ body.no-title .user-menu a:hover {
     font-size: 13px;
     line-height: 13px;
 }
+
 body.no-title .user-menu {
     z-index: 10001;
     background-color: transparent;
 }
+
 body.no-title .user-menu .name {
     color: var(--username-color-dark);
 }
+
 body.no-title .user-menu .email {
     color: var(--email-color-dark);
 }
@@ -475,10 +479,9 @@ span.header {
     margin: 0;
     background: white;
     padding: 5px 3px;
-    border: 2px solid rgba(0,0,0,0.2);
+    border: 2px solid rgba(0, 0, 0, 0.2);
     border-radius: 5px;
 }
-
 
 .content>.element .legend-title {
     font-size: 13px;
@@ -489,13 +492,13 @@ span.header {
     width: fit-content;
 }
 
-
 .content>.element .legend-list {
     margin: 0;
     padding: 0;
     width: fit-content;
     display: flex;
 }
+
 .content>.element .tooltip {
     z-index: 9999;
     position: absolute;
@@ -505,7 +508,7 @@ span.header {
 }
 
 .content>.element .tooltip table {
-    background-color: rgba(0,0,0,0.7);
+    background-color: rgba(0, 0, 0, 0.7);
     padding: 4px 6px 3px !important;
     display: block;
     border-radius: 3px;
@@ -526,11 +529,11 @@ span.header {
     margin-right: 3px;
 }
 
-.content>.element .legend-list .column{
+.content>.element .legend-list .column {
     margin-right: 2px;
 }
 
-.content>.element .legend-list .column:last-child{
+.content>.element .legend-list .column:last-child {
     margin-right: 0;
 }
 
@@ -540,6 +543,7 @@ span.header {
     align-items: center;
     width: fit-content;
 }
+
 .content>.element .legend-item .label {
     width: fit-content;
     font-size: 11px;
@@ -548,11 +552,9 @@ span.header {
     line-break: auto;
 }
 
-
 .content>.element .legend-item .label span {
     display: none;
 }
-
 
 .content>.element .legend-item div.color {
     margin-right: 7px;
@@ -638,11 +640,15 @@ body {
 }
 
 .form-content {
-    margin-bottom: 30px;
     padding: 20px;
-    height: max-content;
+    height: min-content;
     grid-row: auto;
     grid-column: span 3;
+}
+
+.form-content.full-width {
+    max-width: 100%;
+    grid-column: span 4;
 }
 
 .form-content h3 {
@@ -697,7 +703,7 @@ body {
         margin-bottom: 33px;
     }
     body {
-        background: linear-gradient(
+         background: linear-gradient(
             to bottom,
             var(--header-background-color) 0%,
             var(--header-background-color) 230px,
@@ -710,19 +716,21 @@ body {
     }
     .content {
         display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-auto-rows: 200px;
+        grid-template-columns: 1fr;
+        grid-template-rows: repeat(auto-fit, minmax(200px, 33%));
         grid-auto-flow: dense;
         grid-row-gap: var(--gutter-size);
         grid-column-gap: var(--gutter-size);
     }
-    .content.layout-admin {
-        grid-template-columns: 1fr;
-        grid-template-rows: auto;
+    .content.dashboard {
+        grid-template-columns: 1fr 1fr;
+        grid-auto-rows: 200px;
     }
-    .content.layout-admin.action-update {
-        grid-template-columns: 1fr 1fr 1fr 1fr;
-        grid-template-rows: repeat(auto-fit, minmax(200px, 33%));
+    .content.layout-form {
+        grid-template-rows: inherit;
+    }
+    .content.layout-form.controller-element {
+        grid-template-rows: repeat(auto-fit, minmax(200px, 200px));
     }
     .map {
         grid-column: span 1;
@@ -732,12 +740,10 @@ body {
         grid-column: span 2;
         grid-row: span 2;
     }
-
     .user-menu {
         text-align: right;
         padding: 20px 10px 20px 0;
     }
-
     body.no-title .user-menu {
         position: fixed;
         right: 0;
@@ -754,15 +760,12 @@ body {
         background: linear-gradient( to bottom, var(--header-background-color) 0%, var(--header-background-color) 130px, var(--main-background-color) 130px, var(--main-background-color) 100%);
         grid-template-rows: auto auto 1fr;
         grid-template-columns: auto 1fr 1fr 1fr;
-        grid-template-areas:
+         grid-template-areas:
                 "sidebar title title user"
                 "sidebar filters filters filters"
                 "sidebar main main main"
         ;
         height: 100vh;
-    }
-    .content {
-        grid-template-columns: 1fr 1fr;
     }
     .map {
         grid-column: span 2;
@@ -805,16 +808,27 @@ body {
 @media(min-width: 1200px) {
     .content {
         grid-template-columns: 1fr 1fr 1fr;
-        grid-template-rows: repeat(auto-fit, minmax(200px, 33%));
+    }
+    .content.layout-admin {
+        grid-template-columns: 1fr;
+    }
+    .content.dashboard {
+        grid-template-columns: 1fr 1fr 1fr;
     }
     .prime_widgets_chart_Chart, .table {
         grid-row: span 2;
     }
+    .form-content {
+        max-width: 700px;
+    }
 }
 
 @media(min-width: 1460px) {
-    .content {
+    .content, .content.dashboard {
         grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
+    .form-content {
+        max-width: 680px;
     }
     /*.prime_widgets_chart_Chart {*/
     /*grid-row: span 1;*/
@@ -1024,22 +1038,4 @@ body[data-modal]:after {
 .form-horizontal .control-label {
     word-break: break-word;
     padding-right: 4px;
-}
-
-.share-form {
-    padding: 0;
-    margin: 0;
-}
-
-.share-form .list-shared {
-    max-width: 1200px;
-}
-
-
-
-
-@media (min-width: 2706px) {
-    .share-form .list-shared {
-        margin: 0 0 0 20px;
-    }
 }

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -714,24 +714,20 @@ body {
         grid-template-rows: auto auto auto minmax(400px, 1fr);
         grid-template-areas: "title user" "sidebar sidebar" "filters filters" "main main";
     }
+
     .content {
         display: grid;
         grid-template-columns: 1fr;
-        grid-template-rows: repeat(auto-fit, minmax(200px, 33%));
+        grid-template-rows: repeat(auto-fit, minmax(200px, min-content));
         grid-auto-flow: dense;
         grid-row-gap: var(--gutter-size);
         grid-column-gap: var(--gutter-size);
     }
-    .content.dashboard {
-        grid-template-columns: 1fr 1fr;
-        grid-auto-rows: 200px;
+
+    .content.layout-admin {
+        display: block;
     }
-    .content.layout-form {
-        grid-template-rows: inherit;
-    }
-    .content.layout-form.controller-element {
-        grid-template-rows: repeat(auto-fit, minmax(200px, 200px));
-    }
+
     .map {
         grid-column: span 1;
         grid-row: span 2;
@@ -809,24 +805,20 @@ body {
     .content {
         grid-template-columns: 1fr 1fr 1fr;
     }
-    .content.layout-admin {
-        grid-template-columns: 1fr;
-    }
-    .content.dashboard {
-        grid-template-columns: 1fr 1fr 1fr;
-    }
+    
     .prime_widgets_chart_Chart, .table {
         grid-row: span 2;
     }
     .form-content {
-        max-width: 700px;
+        max-width: 730px;
     }
 }
 
 @media(min-width: 1460px) {
-    .content, .content.dashboard {
+    .content {
         grid-template-columns: 1fr 1fr 1fr 1fr;
     }
+    
     .form-content {
         max-width: 680px;
     }

--- a/public/css/form.css
+++ b/public/css/form.css
@@ -62,8 +62,8 @@ form .has-error input{
 /*    padding-left: 15px;*/
 /*    padding-right: 15px;*/
 /*}*/
-.form-group {
-    margin-bottom: 5px;
+.form-group, .form-horizontal .form-group {
+    margin: 0;
 }
 
 .tab-pane {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -136,7 +136,7 @@ a:hover {
         display: block;
         overflow-y: auto;
         position: relative;
-        padding: 10px 10px 100px 10px;
+        padding: 10px;
     }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -359,7 +359,7 @@ a:hover {
     list-style-type: none;
     padding: 0;
     margin: 12px auto;
-    width: max-content;
+    width: fit-content;
 }
 
 .project-summary li {

--- a/public/css/pdf.css
+++ b/public/css/pdf.css
@@ -97,7 +97,7 @@ body {
 .content {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto;
+    grid-template-rows: min-content;
     grid-auto-flow: dense;
     grid-row-gap: var(--gutter-size);
     grid-column-gap: var(--gutter-size);
@@ -147,6 +147,7 @@ body {
 
 .content>.element.map {
     max-height: none;
+    height: 400px;
 }
 
 .leaflet-container a, .content>.element a {


### PR DESCRIPTION
Adapted the remaining admin pages that were still using bootstrap to the grid system

<img width="1410" alt="Capture d’écran 2020-07-08 à 14 02 16" src="https://user-images.githubusercontent.com/2345926/86916292-b00ed680-c123-11ea-9b94-155bc13dd1fa.png">

<img width="1411" alt="Capture d’écran 2020-07-08 à 14 00 39" src="https://user-images.githubusercontent.com/2345926/86916198-881f7300-c123-11ea-9e12-b63b0f31bdc3.png">

fix for #519 and #467