### PR TITLE
Removing colon from popup infos

### DIFF
--- a/protected/widgets/map/assets/DashboardMapRenderer.js
+++ b/protected/widgets/map/assets/DashboardMapRenderer.js
@@ -161,7 +161,7 @@ class DashboardMapRenderer {
             popup += "<div class='hf-content'>";
 
             for (let entry of e.feature.properties.data) {
-                popup += "<div><span>" + entry.title + " : </span>" + entry.value + "</div>";
+                popup += "<div><span>" + entry.title + "</span>" + entry.value + "</div>";
             }
             popup += "</div>";
             if (e.feature.properties.workspace_url != null) {


### PR DESCRIPTION
Removing colon from popup infos. There are not needed and it saves space