### PR TITLE
Add scenarios to project

### DIFF
--- a/protected/models/forms/project/Update.php
+++ b/protected/models/forms/project/Update.php
@@ -7,8 +7,10 @@ namespace prime\models\forms\project;
 use prime\behaviors\LocalizableWriteBehavior;
 use prime\models\ar\Project;
 use prime\objects\enums\ProjectStatus;
+use prime\objects\enums\ProjectType;
 use prime\objects\enums\ProjectVisibility;
 use prime\objects\LanguageSet;
+use prime\traits\StrictModelScenario;
 use prime\validators\ClientJsonValidator;
 use prime\validators\CountryValidator;
 use prime\values\ProjectId;
@@ -22,6 +24,8 @@ use yii\validators\UniqueValidator;
 
 class Update extends Model
 {
+    use StrictModelScenario;
+
     public null|string $country;
     public null|array $i18n;
     public LanguageSet $languages;
@@ -77,5 +81,13 @@ class Update extends Model
             [['typemap', 'overrides'], ClientJsonValidator::class],
             [['country'], CountryValidator::class]
         ];
+    }
+
+    public function scenarios(): array
+    {
+        $result = parent::scenarios();
+        $result[ProjectType::surveyJs()->value] = [...$result[self::SCENARIO_DEFAULT], '!typemap'];
+        $result[ProjectType::limesurvey()->value] = [...$result[self::SCENARIO_DEFAULT]];
+        return $result;
     }
 }

--- a/protected/repositories/ProjectRepository.php
+++ b/protected/repositories/ProjectRepository.php
@@ -60,7 +60,7 @@ class ProjectRepository implements RetrieveReadModelRepositoryInterface
 
         $update = new ProjectUpdate(new ProjectId($record->id));
         $this->hydrator->hydrateFromActiveRecord($update, $record);
-
+        $update->setScenario($record->getType()->value);
         return $update;
     }
 

--- a/protected/traits/StrictModelScenario.php
+++ b/protected/traits/StrictModelScenario.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace prime\traits;
+
+/**
+ * Enables strict scenario checks. This slows down setting a scenario (because it iterates over validators)
+ * but it increases debuggability. The slowdown should not be relevant since this is not called often.
+ */
+trait StrictModelScenario
+{
+
+    public function setScenario($value): void
+    {
+        parent::setScenario($value);
+        if (!isset($this->scenarios()[$value])) {
+            throw new \InvalidArgumentException("Scenario '$value' is not valid");
+        }
+    }
+}

--- a/protected/views/project/update.php
+++ b/protected/views/project/update.php
@@ -111,14 +111,16 @@ echo Form::widget([
             'options' => [
                 'value' => json_encode($model->typemap, JSON_PRETTY_PRINT),
                 'rows' => 5
-            ]
+            ],
+            'visible' => $model->isAttributeSafe('typemap')
         ],
         'overrides' => [
             'type' => Form::INPUT_TEXTAREA,
             'options' => [
                 'value' => json_encode($model->overrides, JSON_PRETTY_PRINT),
                 'rows' => 5
-            ]
+            ],
+
         ],
         FormButtonsWidget::embed([
             'buttons' => [

--- a/protected/views/survey/createAndUpdate.php
+++ b/protected/views/survey/createAndUpdate.php
@@ -37,6 +37,7 @@ $surveyId = Json::encode($model instanceof SurveyForUpdate ? $model->getSurveyId
 echo Creator::widget([
     'options' => [],
     'surveyCreatorCustomizers' => [
+        new JsExpression('(creator) => { creator.toolbox.allowExpandMultipleCategories = true}'),
         new JsExpression(<<<JS
 function(surveyCreator) {
   let surveyId = {$surveyId};

--- a/tests/unit/repositories/ProjectRepositoryTest.php
+++ b/tests/unit/repositories/ProjectRepositoryTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace prime\tests\unit\repositories;
 
+use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
 use prime\helpers\ModelHydrator;
 use prime\interfaces\AccessCheckInterface;
+use prime\models\ar\Permission;
 use prime\models\ar\Project;
+use prime\models\forms\project\Update;
+use prime\models\user\UserForSelect2;
 use prime\repositories\ProjectRepository;
 use prime\values\ProjectId;
 
@@ -28,5 +32,29 @@ class ProjectRepositoryTest extends Unit
 
         $this->assertEquals($project->title, $breadcrumb->getLabel());
         $this->assertEquals(['/project/view', 'id' => $project->id], $breadcrumb->getUrl());
+    }
+
+
+    public function testRetrieveForUpdate(): void
+    {
+        $project = Project::findOne(['id' => 1]);
+
+        $accessChecker = $this->getMockBuilder(AccessCheckInterface::class)->disableOriginalConstructor()->getMock();
+
+        // Test that permission is checked
+        $accessChecker->expects($this->once())->method('requirePermission')->willReturnCallback(function ($subject, $permission) use ($project) {
+            $this->assertTrue($project->equals($subject));
+            $this->assertSame(Permission::PERMISSION_WRITE, $permission);
+        });
+
+        $modelHydrator = $this->getMockBuilder(ModelHydrator::class)->disableOriginalConstructor()->getMock();
+        // Test that hydrator is called
+        $modelHydrator->expects($this->once())->method('hydrateFromActiveRecord');
+        $projectRepository = new ProjectRepository($accessChecker, $modelHydrator);
+
+        $retrieved = $projectRepository->retrieveForUpdate(new ProjectId($project->id));
+        $this->assertInstanceOf(Update::class, $retrieved);
+        // Test that scenario is set
+        $this->assertNotSame(Update::SCENARIO_DEFAULT, $retrieved->getScenario());
     }
 }

--- a/tests/unit/traits/StrictModelScenarioTest.php
+++ b/tests/unit/traits/StrictModelScenarioTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace prime\tests\unit\traits;
+
+use Codeception\Test\Unit;
+use prime\traits\StrictModelScenario;
+use yii\base\Model;
+
+/**
+ * No covers annotation since they don't work for traits
+ */
+class StrictModelScenarioTest extends Unit
+{
+
+    public function testInvalidScenarioThrowsException()
+    {
+        $subject = new class extends Model {
+            use StrictModelScenario;
+
+            public string $a = 'test';
+
+            public function scenarios(): array
+            {
+                return [
+                    'scenario1' => ['a']
+                ];
+            }
+        };
+
+        $this->assertNotSame('scenario1', $subject->getScenario());
+        $subject->setScenario('scenario1');
+
+        $this->assertSame('scenario1', $subject->getScenario());
+        $this->expectException(\InvalidArgumentException::class);
+        $subject->setScenario('scenario2');
+    }
+}


### PR DESCRIPTION
This PR adds scenarios to the update model for the different project types.
This is then used in the update screen to hide settings that do not apply.

Tests have been added to the new trait as well as the repository that didn't have them yet.